### PR TITLE
Replace single quotes for `import` with double quotes

### DIFF
--- a/definitions/base.json
+++ b/definitions/base.json
@@ -8,7 +8,7 @@
         
         "import": {
             "description": "Imports a Solidity file",
-            "snippet": "import '${1}'${2}",
+            "snippet": "import \"${1}\"${2}",
             "type": "import"
         },
         


### PR DESCRIPTION
Reasoning:
When attempting to use the automatically provided snippet that utilises single quotes, the Solidity compiler throws the following error when trying to `import` the `Task.sol` file (which is in the same directory as the entry point .sol file being compiled):

```
Error compiling contracts
exit status 1; acc3bfbc0bcdda1626fe732d723192a145bcda0fee759662e0d76790a8336595.sol:1:1: Error: Source not found: File not found.
import 'Task.sol';
^----------------^
```

Replacing the single quotes with double quotes resolves this misleading error.
