### PR TITLE
Updated base.json to include 'constructor'

### DIFF
--- a/definitions/base.json
+++ b/definitions/base.json
@@ -31,6 +31,11 @@
             "type": "keyword"
         },
         
+        "constructor": {
+            "text": "constructor ${1:yourContractsName}(${2}) ${3}{\n\t${4}\n}",
+            "type": "keyword"
+        },
+        
         "external": {
             "description": "Sets the visibility to contracts only",
             "descriptionMoreURL": "https://github.com/ethereum/wiki/wiki/Solidity-Features#visibility-specifiers-1",


### PR DESCRIPTION
It would be cool if it would parse the contract's name and suggest it, but I don't know how to do that.